### PR TITLE
Remove the ability to set depreciated fields

### DIFF
--- a/wins/templates/wins/partials/form-checkbox-legacy.html
+++ b/wins/templates/wins/partials/form-checkbox-legacy.html
@@ -1,0 +1,3 @@
+{% if field.value %}
+	{% include "wins/partials/form-checkbox.html" %}
+{% endif %}

--- a/wins/templates/wins/partials/win-details-element-legacy-field.html
+++ b/wins/templates/wins/partials/win-details-element-legacy-field.html
@@ -1,0 +1,7 @@
+{% comment %}
+For fields that have been removed in the current version of the export win form,
+we still want to show their value iff they've been set in the past.
+{% endcomment %}
+{% if val %}
+	{% include "wins/partials/win-details-element.html" %}
+{% endif %}

--- a/wins/templates/wins/partials/win-form.html
+++ b/wins/templates/wins/partials/win-form.html
@@ -247,9 +247,9 @@
 		</p>
 
 		{% include "wins/partials/win-field.html" with field=form.hvc class="restrict-width" %}
-		{% include "wins/partials/form-checkbox.html" with field=form.has_hvo_specialist_involvement %}
-		{% include "wins/partials/form-checkbox.html" with field=form.is_prosperity_fund_related %}
-		{% include "wins/partials/form-checkbox.html" with field=form.is_e_exported %}
+		{% include "wins/partials/form-checkbox-legacy.html" with field=form.has_hvo_specialist_involvement %}
+		{% include "wins/partials/form-checkbox-legacy.html" with field=form.is_prosperity_fund_related %}
+		{% include "wins/partials/form-checkbox-legacy.html" with field=form.is_e_exported %}
 
 		<div class="add-select-group">
 			{% include "wins/partials/win-field.html" with field=form.type_of_support_1 class="restrict-width support-group" %}

--- a/wins/templates/wins/win-details.html
+++ b/wins/templates/wins/win-details.html
@@ -245,9 +245,9 @@
   <div class="section-content">
     {% include "wins/partials/win-details-element.html" with name="HVC code, if applicable" val=win.hvc|default:"None" required=False %}
     {% include "wins/partials/win-details-element.html" with name="HVO Programme, if applicable" val=win.hvo_programme|default:"None" required=False %}
-    {% include "wins/partials/win-details-element.html" with name="Have HVO Specialists been involved" val=win.has_hvo_specialist_involvement %}
-    {% include "wins/partials/win-details-element.html" with name="Is this win Prosperity Fund related" val=win.is_prosperity_fund_related %}
-    {% include "wins/partials/win-details-element.html" with name="Does the win relate to e-exporting" val=win.is_e_exported %}
+    {% include "wins/partials/win-details-element-legacy-field.html" with name="Have HVO Specialists been involved" val=win.has_hvo_specialist_involvement %}
+    {% include "wins/partials/win-details-element-legacy-field.html" with name="Is this win Prosperity Fund related" val=win.is_prosperity_fund_related %}
+    {% include "wins/partials/win-details-element-legacy-field.html" with name="Does the win relate to e-exporting" val=win.is_e_exported %}
     {% include "wins/partials/win-details-element.html" with name="Type of support 1" val=win.type_of_support_1 %}
     {% include "wins/partials/win-details-element.html" with name="Type of support 2" val=win.type_of_support_2 required=False %}
     {% include "wins/partials/win-details-element.html" with name="Type of support 3" val=win.type_of_support_3 required=False %}


### PR DESCRIPTION
* "An HVO specialist was involved"
* "Prosperity fund"
* "E-exporting programme"

will not be settable or appear on the win details screen.

If they have been previously set then they'll still show up.