### PR TITLE
User login issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+venv/
 env/
 build/
 develop-eggs/

--- a/wins/views.py
+++ b/wins/views.py
@@ -72,13 +72,16 @@ class MyWinsView(LoginRequiredMixin, TemplateView):
             key=lambda w: w['company_name'],
         )
 
+        # skip ones that weren't yet sent as well as not responded yet
+        # better to show not sent wins as a seperate table in UI
         sent = [
             w for w in wins
-            if w['complete'] and w not in context['responded']
+            if w['complete'] and w['sent'] and w not in context['responded']
         ]
+
         context['sent'] = sorted(
             sent,
-            key=lambda w: w['sent'][0] if len(w['sent']) else 0,
+            key=lambda w: w['sent'][0],
             reverse=True,
         )
 


### PR DESCRIPTION
sorting of sent wins is breaking when wins were not sent. For some reason this user has wins from last year that weren't yet sent or may be sent records were disabled. This is causing sorting of these wins to break. I have now excluded unsent wins from that list. This shouldn't cause any problem for normal users as wins are normally sent to the customer as soon as they mark them as complete. This user has a weird situation with few old unsent wins. But it might be a good idea to show these wins as separate table in the UI