### PR TITLE
Add cache-control, HSTS and HttpOnly headers

### DIFF
--- a/ui/middleware.py
+++ b/ui/middleware.py
@@ -12,3 +12,11 @@ class SSLRedirectMiddleware(MiddlewareMixin):
             if "runserver" not in sys.argv and "test" not in sys.argv:
                 return HttpResponseRedirect(urlunsplit(
                     ["https"] + list(urlsplit(request.get_raw_uri())[1:])))
+
+
+class CacheControlMiddleware(MiddlewareMixin):
+
+    def process_response(self, request, response):
+        response['Pragma'] = 'no-cache'
+        response['Cache-Control'] = 'max-age=0, no-cache, no-store, must-revalidate, private'
+        return response

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'ui.middleware.SSLRedirectMiddleware',
+    'ui.middleware.CacheControlMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     "alice.middleware.AliceMiddleware",
@@ -215,9 +216,12 @@ RAVEN_CONFIG = {
 
 # Security stuff
 SECURE_HSTS_SECONDS = 60 * 60 * 24 * 365
+SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+SECURE_HSTS_PRELOAD = True
 SECURE_BROWSER_XSS_FILTER = True
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
+CSRF_COOKIE_HTTPONLY = True
 if DEBUG:
     SESSION_COOKIE_SECURE = False
     CSRF_COOKIE_SECURE = False

--- a/ui/tests.py
+++ b/ui/tests.py
@@ -1,0 +1,25 @@
+import datetime
+
+import responses
+from django.test import Client, TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+
+class MiddlewareTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    @responses.activate
+    def test_cache_control_middleware(self):
+        responses.add(
+            method=responses.GET,
+            url='http://127.0.0.1:8000/limited-wins/123456789012345678901234567890123456/',
+            json={'created': str(timezone.now() - datetime.timedelta(weeks=53))},
+            status=200,
+            content_type='application/json',
+        )
+
+        response = self.client.get(reverse('responses', kwargs={'win_id': '123456789012345678901234567890123456'}))
+        assert response['Pragma'] == 'no-cache'
+        assert response['Cache-Control'] == 'max-age=0, no-cache, no-store, must-revalidate, private'


### PR DESCRIPTION
According to pen test report we were advised to add this changes:
- Cache-Control headers
- X-XSS-Protection headers
- HttpOnly on csrftoken cookie
