### PR TITLE
Added configurable review form acceptance window

### DIFF
--- a/ui/settings.py
+++ b/ui/settings.py
@@ -206,6 +206,7 @@ ANALYTICS_ID = os.getenv("ANALYTICS_ID")
 
 # how long you can edit a win
 EDIT_TIMEOUT_DAYS = int(os.getenv('EDIT_TIMEOUT_DAYS', 120))
+REVIEW_WINDOW_DAYS = int(os.getenv('REVIEW_WINDOW_DAYS', 365 + 31))
 
 
 # Sentry

--- a/wins/tests.py
+++ b/wins/tests.py
@@ -1,11 +1,10 @@
 import datetime
-from unittest import mock
-
 import responses
 from django.conf import settings
 from django.test import Client, TestCase
 from django.urls import reverse
 from django.utils import timezone
+from unittest import mock
 
 mock.patch('alice.metaclasses.rabbit', spec=True).start()
 
@@ -52,9 +51,12 @@ class ConfirmationFormTest(TestCase):
     @responses.activate
     def test_fails_with_old_win(self):
         self._add_common_resp()
-        responses.add(responses.GET, 'http://127.0.0.1:8000/limited-wins/123456789012345678901234567890123456/',
-                      json={'created': str(timezone.now() - datetime.timedelta(weeks=53))},
-                      status=200, content_type='application/json')
+        responses.add(
+            responses.GET,
+            'http://127.0.0.1:8000/limited-wins/123456789012345678901234567890123456/',
+            json={'created': str(timezone.now() - datetime.timedelta(days=settings.REVIEW_WINDOW_DAYS + 2))},
+            status=200, content_type='application/json'
+        )
         self._login()
         resp = self.client.get(reverse('responses', kwargs={'win_id': '123456789012345678901234567890123456'}))
         self.assertNotContains(resp, 'Please review this information')

--- a/wins/views.py
+++ b/wins/views.py
@@ -323,7 +323,6 @@ class ConfirmationView(FormView):
 
     # limit the number of days form may be accessed after win submission for
     # security purposes
-    ACCEPTANCE_WINDOW = 365
 
     sample = False  # is this a sample win, which will not be saved?
 
@@ -396,9 +395,9 @@ class ConfirmationView(FormView):
 
         win_dict = win_resp.json()
 
-        # is it within security window?
+        # is it within security acceptance window?
         created = date_parser(win_dict["created"])
-        window_extent = created + relativedelta(days=self.ACCEPTANCE_WINDOW)
+        window_extent = created + relativedelta(days=settings.REVIEW_WINDOW_DAYS)
         now = timezone.now()
         if now > window_extent:
             raise self.SecurityException(


### PR DESCRIPTION
There was a request from from customer to increase review form acceptance window to a bit more than a year. This change increases this window as well as makes this setting configurable.