### PR TITLE
Update use of jwt decode/encode methods

### DIFF
--- a/alice/middleware.py
+++ b/alice/middleware.py
@@ -10,7 +10,6 @@ logger = logging.getLogger(__name__)
 
 
 class AliceMiddleware(MiddlewareMixin):
-
     def process_request(self, request):
 
         alice = request.COOKIES.get("alice")
@@ -20,10 +19,10 @@ class AliceMiddleware(MiddlewareMixin):
 
         if alice:
             try:
-                token = jwt.decode(alice, settings.COOKIE_SECRET)
+                token = jwt.decode(alice, settings.COOKIE_SECRET, algorithms=["HS256"])
                 # alice id is given to data server as session id for authentication
                 # via Rabbit
                 request.alice_id = token["session"]
                 request.user = User(**token["user"])
             except:
-                logger.exception('Error decoding Alice!')
+                logger.exception("Error decoding Alice!")

--- a/users/views.py
+++ b/users/views.py
@@ -53,10 +53,8 @@ def oauth_callback_view(request):
 
     logger.debug(f"redirect to {next_url} for user {user['email']} and session {session_cookie.value}")
     #
-    jwt_val = jwt.encode({
-        "user": user,
-        "session": session_cookie.value
-    },
+    jwt_val = jwt.encode(
+        {"user": user, "session": session_cookie.value},
         settings.COOKIE_SECRET,
         algorithm="HS256",
     )

--- a/users/views.py
+++ b/users/views.py
@@ -59,7 +59,7 @@ def oauth_callback_view(request):
     },
         settings.COOKIE_SECRET,
         algorithm="HS256",
-    ).decode("utf-8")
+    )
 
     logger.debug(jwt_val)
 

--- a/users/views.py
+++ b/users/views.py
@@ -58,7 +58,7 @@ def oauth_callback_view(request):
         "session": session_cookie.value
     },
         settings.COOKIE_SECRET,
-        "HS256",
+        algorithm="HS256",
     ).decode("utf-8")
 
     logger.debug(jwt_val)


### PR DESCRIPTION
This PR updates our usage of the `jwt.encode()` and `jwt.decode()` methods, so that our code is compatible with latest version of pyjwt (2.4.0)