### PR TITLE
Load .env file on startup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ defusedcsv==2.0.0
 boto3==1.26.8
 
 responses==0.22.0
+python-dotenv==0.10.5

--- a/ui/settings.py
+++ b/ui/settings.py
@@ -12,6 +12,10 @@ https://docs.djangoproject.com/en/1.9/ref/settings/
 
 import os
 
+from dotenv import find_dotenv, load_dotenv
+
+load_dotenv(find_dotenv(), verbose=True)
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 BASE_DIR = os.path.dirname(PROJECT_ROOT)


### PR DESCRIPTION
Include the `dotenv` package and load the .env files inside the `settings.py` file before calling `os.getenv()`

This is already implemented inside the export-wins-data repo: https://github.com/uktrade/export-wins-data/blob/master/data/settings.py