### PR TITLE
bugfix/revert-grunt-saas-upgrade-causing-build-failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {
-        "grunt": "^1.5.3",
+        "grunt": "~1.5.3",
         "grunt-cli": "1.4.3",
         "grunt-contrib-concat": "^2.1.0",
         "grunt-contrib-uglify": "^5.2.2",
@@ -537,6 +537,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/string-template": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
@@ -578,9 +590,9 @@
       }
     },
     "node_modules/dateformat": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
-      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -776,30 +788,32 @@
       }
     },
     "node_modules/grunt": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.1.tgz",
-      "integrity": "sha512-/ABUy3gYWu5iBmrUSRBP97JLpQUm0GgVveDCp6t3yRNIoltIYw7rEj3g5y1o2PGPR2vfTRGa7WC/LZHLTXnEzA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.5.3.tgz",
+      "integrity": "sha512-mKwmo4X2d8/4c/BmcOETHek675uOqw0RuA/zy12jaspWqvTp4+ZeQF1W+OTpcbncnaBsfbQJ6l0l4j+Sn/GmaQ==",
       "dev": true,
       "dependencies": {
-        "dateformat": "~4.6.2",
+        "dateformat": "~3.0.3",
         "eventemitter2": "~0.4.13",
         "exit": "~0.1.2",
-        "findup-sync": "~5.0.0",
+        "findup-sync": "~0.3.0",
         "glob": "~7.1.6",
         "grunt-cli": "~1.4.3",
         "grunt-known-options": "~2.0.0",
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
-        "iconv-lite": "~0.6.3",
+        "iconv-lite": "~0.4.13",
         "js-yaml": "~3.14.0",
         "minimatch": "~3.0.4",
-        "nopt": "~3.0.6"
+        "mkdirp": "~1.0.4",
+        "nopt": "~3.0.6",
+        "rimraf": "~3.0.2"
       },
       "bin": {
         "grunt": "bin/grunt"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=8"
       }
     },
     "node_modules/get-intrinsic": {
@@ -945,6 +959,21 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/underscore.string": {
@@ -1254,18 +1283,15 @@
       }
     },
     "node_modules/findup-sync": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
-      "integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+      "integrity": "sha512-z8Nrwhi6wzxNMIbxlrTzuUW6KWuKkogZ/7OdDVq+0+kxn77KUH1nipx8iU6suqkHqc4y6n7a9A8IpmxY/pTjWg==",
       "dev": true,
       "dependencies": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^4.0.3",
-        "micromatch": "^4.0.4",
-        "resolve-dir": "^1.0.1"
+        "glob": "~5.0.0"
       },
       "engines": {
-        "node": ">= 10.13.0"
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/http-parser-js": {
@@ -1787,15 +1813,31 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "safer-buffer": ">= 2.1.2 < 3"
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
+      "dev": true,
+      "dependencies": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/gaze": {
@@ -2051,9 +2093,9 @@
       "dev": true
     },
     "dateformat": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
-      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true
     },
     "detect-file": {
@@ -2153,15 +2195,27 @@
       }
     },
     "findup-sync": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
-      "integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+      "integrity": "sha512-z8Nrwhi6wzxNMIbxlrTzuUW6KWuKkogZ/7OdDVq+0+kxn77KUH1nipx8iU6suqkHqc4y6n7a9A8IpmxY/pTjWg==",
       "dev": true,
       "requires": {
-        "detect-file": "^1.0.0",
-        "is-glob": "^4.0.3",
-        "micromatch": "^4.0.4",
-        "resolve-dir": "^1.0.1"
+        "glob": "~5.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "fined": {
@@ -2302,24 +2356,26 @@
       }
     },
     "grunt": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.1.tgz",
-      "integrity": "sha512-/ABUy3gYWu5iBmrUSRBP97JLpQUm0GgVveDCp6t3yRNIoltIYw7rEj3g5y1o2PGPR2vfTRGa7WC/LZHLTXnEzA==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.5.3.tgz",
+      "integrity": "sha512-mKwmo4X2d8/4c/BmcOETHek675uOqw0RuA/zy12jaspWqvTp4+ZeQF1W+OTpcbncnaBsfbQJ6l0l4j+Sn/GmaQ==",
       "dev": true,
       "requires": {
-        "dateformat": "~4.6.2",
+        "dateformat": "~3.0.3",
         "eventemitter2": "~0.4.13",
         "exit": "~0.1.2",
-        "findup-sync": "~5.0.0",
+        "findup-sync": "~0.3.0",
         "glob": "~7.1.6",
         "grunt-cli": "~1.4.3",
         "grunt-known-options": "~2.0.0",
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
-        "iconv-lite": "~0.6.3",
+        "iconv-lite": "~0.4.13",
         "js-yaml": "~3.14.0",
         "minimatch": "~3.0.4",
-        "nopt": "~3.0.6"
+        "mkdirp": "~1.0.4",
+        "nopt": "~3.0.6",
+        "rimraf": "~3.0.2"
       }
     },
     "grunt-cli": {
@@ -2510,12 +2566,12 @@
       "dev": true
     },
     "iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "immutable": {
@@ -2771,6 +2827,12 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.3",
@@ -3051,6 +3113,15 @@
       "dev": true,
       "requires": {
         "resolve-from": "^5.0.0"
+      }
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
       }
     },
     "safe-buffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,14 @@
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {
-        "grunt": "~1.5.3",
+        "grunt": "^1.5.3",
         "grunt-cli": "1.4.3",
         "grunt-contrib-concat": "^2.1.0",
         "grunt-contrib-uglify": "^5.2.2",
         "grunt-contrib-watch": "^1.1.0",
         "grunt-sass": "^3.1.0",
         "load-grunt-tasks": "^5.1.0",
-        "sass": "^1.59.2"
+        "sass": "^1.57.1"
       }
     },
     "node_modules/argparse": {
@@ -245,20 +245,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/@types/minimatch": {
@@ -756,9 +742,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.59.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.59.2.tgz",
-      "integrity": "sha512-jJyO6SmbzkJexF8MUorHx5tAilcgabioYxT/BHbY4+OvoqmbHxsYlrjZ8Adhqcgl6Zqwie0TgMXLCAmPFxXOuw==",
+      "version": "1.57.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.57.1.tgz",
+      "integrity": "sha512-O2+LwLS79op7GI0xZ8fqzF7X2m/m8WFfI02dHOdsK5R2ECeS5F62zrwg/relM1rjSLy7Vd/DiMNIvPrQGsA0jw==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -2258,13 +2244,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -3143,9 +3122,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.59.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.59.2.tgz",
-      "integrity": "sha512-jJyO6SmbzkJexF8MUorHx5tAilcgabioYxT/BHbY4+OvoqmbHxsYlrjZ8Adhqcgl6Zqwie0TgMXLCAmPFxXOuw==",
+      "version": "1.57.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.57.1.tgz",
+      "integrity": "sha512-O2+LwLS79op7GI0xZ8fqzF7X2m/m8WFfI02dHOdsK5R2ECeS5F62zrwg/relM1rjSLy7Vd/DiMNIvPrQGsA0jw==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {
-        "grunt": "^1.6.1",
+        "grunt": "^1.5.3",
         "grunt-cli": "1.4.3",
         "grunt-contrib-concat": "^2.1.0",
         "grunt-contrib-uglify": "^5.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {
-        "grunt": "^1.5.3",
+        "grunt": "^1.6.1",
         "grunt-cli": "1.4.3",
         "grunt-contrib-concat": "^2.1.0",
         "grunt-contrib-uglify": "^5.2.2",
@@ -523,18 +523,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/string-template": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
@@ -576,9 +564,9 @@
       }
     },
     "node_modules/dateformat": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -774,32 +762,30 @@
       }
     },
     "node_modules/grunt": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.5.3.tgz",
-      "integrity": "sha512-mKwmo4X2d8/4c/BmcOETHek675uOqw0RuA/zy12jaspWqvTp4+ZeQF1W+OTpcbncnaBsfbQJ6l0l4j+Sn/GmaQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.1.tgz",
+      "integrity": "sha512-/ABUy3gYWu5iBmrUSRBP97JLpQUm0GgVveDCp6t3yRNIoltIYw7rEj3g5y1o2PGPR2vfTRGa7WC/LZHLTXnEzA==",
       "dev": true,
       "dependencies": {
-        "dateformat": "~3.0.3",
+        "dateformat": "~4.6.2",
         "eventemitter2": "~0.4.13",
         "exit": "~0.1.2",
-        "findup-sync": "~0.3.0",
+        "findup-sync": "~5.0.0",
         "glob": "~7.1.6",
         "grunt-cli": "~1.4.3",
         "grunt-known-options": "~2.0.0",
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
-        "iconv-lite": "~0.4.13",
+        "iconv-lite": "~0.6.3",
         "js-yaml": "~3.14.0",
         "minimatch": "~3.0.4",
-        "mkdirp": "~1.0.4",
-        "nopt": "~3.0.6",
-        "rimraf": "~3.0.2"
+        "nopt": "~3.0.6"
       },
       "bin": {
         "grunt": "bin/grunt"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
       }
     },
     "node_modules/get-intrinsic": {
@@ -945,21 +931,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/underscore.string": {
@@ -1269,15 +1240,18 @@
       }
     },
     "node_modules/findup-sync": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-      "integrity": "sha512-z8Nrwhi6wzxNMIbxlrTzuUW6KWuKkogZ/7OdDVq+0+kxn77KUH1nipx8iU6suqkHqc4y6n7a9A8IpmxY/pTjWg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
+      "integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
       "dev": true,
       "dependencies": {
-        "glob": "~5.0.0"
+        "detect-file": "^1.0.0",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.4",
+        "resolve-dir": "^1.0.1"
       },
       "engines": {
-        "node": ">= 0.6.0"
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/http-parser-js": {
@@ -1799,31 +1773,15 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/findup-sync/node_modules/glob": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
-      "dev": true,
-      "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/gaze": {
@@ -2079,9 +2037,9 @@
       "dev": true
     },
     "dateformat": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
       "dev": true
     },
     "detect-file": {
@@ -2181,27 +2139,15 @@
       }
     },
     "findup-sync": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-      "integrity": "sha512-z8Nrwhi6wzxNMIbxlrTzuUW6KWuKkogZ/7OdDVq+0+kxn77KUH1nipx8iU6suqkHqc4y6n7a9A8IpmxY/pTjWg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
+      "integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
       "dev": true,
       "requires": {
-        "glob": "~5.0.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
-          "dev": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
+        "detect-file": "^1.0.0",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.4",
+        "resolve-dir": "^1.0.1"
       }
     },
     "fined": {
@@ -2335,26 +2281,24 @@
       }
     },
     "grunt": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.5.3.tgz",
-      "integrity": "sha512-mKwmo4X2d8/4c/BmcOETHek675uOqw0RuA/zy12jaspWqvTp4+ZeQF1W+OTpcbncnaBsfbQJ6l0l4j+Sn/GmaQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.1.tgz",
+      "integrity": "sha512-/ABUy3gYWu5iBmrUSRBP97JLpQUm0GgVveDCp6t3yRNIoltIYw7rEj3g5y1o2PGPR2vfTRGa7WC/LZHLTXnEzA==",
       "dev": true,
       "requires": {
-        "dateformat": "~3.0.3",
+        "dateformat": "~4.6.2",
         "eventemitter2": "~0.4.13",
         "exit": "~0.1.2",
-        "findup-sync": "~0.3.0",
+        "findup-sync": "~5.0.0",
         "glob": "~7.1.6",
         "grunt-cli": "~1.4.3",
         "grunt-known-options": "~2.0.0",
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
-        "iconv-lite": "~0.4.13",
+        "iconv-lite": "~0.6.3",
         "js-yaml": "~3.14.0",
         "minimatch": "~3.0.4",
-        "mkdirp": "~1.0.4",
-        "nopt": "~3.0.6",
-        "rimraf": "~3.0.2"
+        "nopt": "~3.0.6"
       }
     },
     "grunt-cli": {
@@ -2545,12 +2489,12 @@
       "dev": true
     },
     "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
     "immutable": {
@@ -2806,12 +2750,6 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
-    },
-    "mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true
     },
     "ms": {
       "version": "2.1.3",
@@ -3092,15 +3030,6 @@
       "dev": true,
       "requires": {
         "resolve-from": "^5.0.0"
-      }
-    },
-    "rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.3"
       }
     },
     "safe-buffer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "grunt-contrib-watch": "^1.1.0",
         "grunt-sass": "^3.1.0",
         "load-grunt-tasks": "^5.1.0",
-        "sass": "^1.57.1"
+        "sass": "1.57.1"
       }
     },
     "node_modules/argparse": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/UKTradeInvestment/export-wins-ui#readme",
   "devDependencies": {
-    "grunt": "^1.6.1",
+    "grunt": "^1.5.3",
     "grunt-cli": "1.4.3",
     "grunt-contrib-concat": "^2.1.0",
     "grunt-contrib-uglify": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt-contrib-watch": "^1.1.0",
     "grunt-sass": "^3.1.0",
     "load-grunt-tasks": "^5.1.0",
-    "sass": "^1.57.1"
+    "sass": "1.57.1"
   },
   "resolutions": {
     "set-value": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/UKTradeInvestment/export-wins-ui#readme",
   "devDependencies": {
-    "grunt": "^1.5.3",
+    "grunt": "~1.5.3",
     "grunt-cli": "1.4.3",
     "grunt-contrib-concat": "^2.1.0",
     "grunt-contrib-uglify": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/UKTradeInvestment/export-wins-ui#readme",
   "devDependencies": {
-    "grunt": "~1.5.3",
+    "grunt": "1.5.3",
     "grunt-cli": "1.4.3",
     "grunt-contrib-concat": "^2.1.0",
     "grunt-contrib-uglify": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
   },
   "homepage": "https://github.com/UKTradeInvestment/export-wins-ui#readme",
   "devDependencies": {
-    "grunt": "1.5.3",
+    "grunt": "^1.5.3",
     "grunt-cli": "1.4.3",
     "grunt-contrib-concat": "^2.1.0",
     "grunt-contrib-uglify": "^5.2.2",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-sass": "^3.1.0",
     "load-grunt-tasks": "^5.1.0",
-    "sass": "^1.59.2"
+    "sass": "^1.57.1"
   },
   "resolutions": {
     "set-value": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/UKTradeInvestment/export-wins-ui#readme",
   "devDependencies": {
-    "grunt": "^1.5.3",
+    "grunt": "^1.6.1",
     "grunt-cli": "1.4.3",
     "grunt-contrib-concat": "^2.1.0",
     "grunt-contrib-uglify": "^5.2.2",


### PR DESCRIPTION
Using a version of sass above v1.57.1 is causing a build error inside Jenkins. This PR reverts the previous Dependabot PR and pins this version to v1.57.1

![image](https://user-images.githubusercontent.com/102232401/224754154-d3ac1290-d644-4240-820c-61cad31de054.png)
