### PR TITLE
Update message in banner about moving to Data Hub

### DIFF
--- a/ui/templates/ui/base.html
+++ b/ui/templates/ui/base.html
@@ -77,7 +77,7 @@
           href="https://data-services-help.trade.gov.uk/data-hub/updates/announcements/export-wins-is-moving-to-data-hub/"
           style="color: white; text-decoration: underline;"
         >
-          Export Wins is moving to Data Hub on 3 April 2024
+          Export Wins is moving to Data Hub shortly
         </a>
       </p>
 


### PR DESCRIPTION
## Description of change

Updated the export wins announcment banner from "Important: Export Wins is moving to Data Hub on 3 April 2024" to " "Important: Export Wins is moving to Data Hub shortly".