### PR TITLE
Fix the missing edit export win form

### DIFF
--- a/wins/templates/wins/partials/win-form.html
+++ b/wins/templates/wins/partials/win-form.html
@@ -1,5 +1,422 @@
 {% extends 'ui/base.html' %}
 
+{% load humanize %}
+
 {% block content %}
-	{% include "wins/partials/moving-to-datahub.html" %}
+
+<style>
+	.collapsible-container {
+		display: flex;
+		align-items: center;
+		background-color: #ffffff;
+		border-left: 5px solid #000000;
+		padding: 0.5rem;
+	}
+
+	.collapsible-text {
+		margin-right: auto;
+		color: #000000;
+		font-size: 1.2em;
+		cursor: pointer;
+	}
+
+	.collapsible-button {
+		background-color: transparent;
+		color: #000000;
+		cursor: pointer;
+		border: none;
+		outline: none;
+		font-size: 1.5em;
+	}
+
+	.collapsible-content {
+		background-color: transparent;
+		overflow: hidden;
+		transition: max-height 0.2s ease-out;
+		max-height: 0;
+		padding-left: 18px;
+		padding-right: 18px;
+	}
+
+	.content-inner {
+		border-top: 1px solid #ccc;
+		padding: 0.5rem 0;
+	}
+
+	.collapsible-button.active {
+		transform: rotate(-180deg);
+	}
+</style>
+
+<div class="win-form">
+
+	{% if form.errors %}
+		<div class="alert alert-danger">
+			There were some errors with your submission.  Please see below.
+		</div>
+		{# note, non field errors are used below {{ form.non_field_errors }} #}
+	{% endif %}
+
+	<p>The Lead officer should provide the information for this form.</p>
+
+	{% if win.complete %}
+
+	<p class="alert alert-info">
+		This win has been sent to the customer for review and certain information cannot be edited any more.
+	</p>
+
+	{% endif %}
+
+	<form method="post" id="win-form">
+
+    {% csrf_token %}
+
+		<h3 class="form-section-heading">Officer details</h3>
+		{% include "wins/partials/win-field.html" with field=form.lead_officer_name class="restrict-width-sm" %}
+		<div class="row">
+			<div class="col-sm-4">
+				{% include "wins/partials/win-field.html" with field=form.team_type %}
+			</div>
+			<div class="col-sm-8">
+				{% include "wins/partials/win-field.html" with field=form.hq_team %}
+			</div>
+		</div>
+		{% include "wins/partials/win-field.html" with field=form.line_manager_name class="restrict-width-sm" %}
+		{% include "wins/partials/win-field.html" with field=form.lead_officer_email_address help="You only need to provide this if you are completing this form on behalf of the lead officer" class="restrict-width-sm" %}
+		{% include "wins/partials/win-field.html" with field=form.other_official_email_address help="If another officer from your team should be kept notified, provide their email address" class="restrict-width-sm" %}
+
+
+		<div class="form-group has-contributors">
+			<h3>
+				Credit for this win
+			</h3>
+
+			<h4 class="radio-label">
+				<span class="required">*</span>Did any other teams help with this win?
+			</h4>
+
+			<div class="radio">
+				<label for="no-contributors">
+					<input type="radio" id="no-contributors" name="has-contributors" value="no">
+					This was the only team that worked on this win
+				</label>
+			</div>
+
+			<div class="radio">
+				<label for="some-contributors">
+					<input type="radio" id="some-contributors" name="has-contributors" value="yes" {% if form.advisor_0_name.value %} checked{% endif %}>
+					More than one team contributed to this win
+				</label>
+			</div>
+
+		</div>
+
+		<div id="contributing-teams-details" class="contributing-teams-content">
+			<h4>Contributing teams and advisors</h4>
+			<p class="text-muted">
+				Up to 5 teams and advisors can be added, please choose the teams that contributed the most.
+			</p>
+
+			{% include "wins/partials/win-contributor.html" with name=form.advisor_0_name id=form.advisor_0_id team_type=form.advisor_0_team_type team=form.advisor_0_hq_team team_error=form.advisor_0_hq_team.errors %}
+			{% include "wins/partials/win-contributor.html" with name=form.advisor_1_name id=form.advisor_1_id team_type=form.advisor_1_team_type team=form.advisor_1_hq_team team_error=form.advisor_1_hq_team.errors %}
+			{% include "wins/partials/win-contributor.html" with name=form.advisor_2_name id=form.advisor_2_id team_type=form.advisor_2_team_type team=form.advisor_2_hq_team team_error=form.advisor_2_hq_team.errors %}
+			{% include "wins/partials/win-contributor.html" with name=form.advisor_3_name id=form.advisor_3_id team_type=form.advisor_3_team_type team=form.advisor_3_hq_team team_error=form.advisor_3_hq_team.errors %}
+			{% include "wins/partials/win-contributor.html" with name=form.advisor_4_name id=form.advisor_4_id team_type=form.advisor_4_team_type team=form.advisor_4_hq_team team_error=form.advisor_4_hq_team.errors %}
+		</div>
+
+
+		<h3 class="form-section-heading">Customer details</h3>
+
+		{% include "wins/partials/win-field.html" with field=form.company_name class="restrict-width-lg" %}
+		{% include "wins/partials/win-field.html" with field=form.cdms_reference class="restrict-width-sm" %}
+		{% include "wins/partials/win-field.html" with field=form.customer_name class="restrict-width-sm" %}
+		{% include "wins/partials/win-field.html" with field=form.customer_email_address class="restrict-width-sm" help="We will send the customer form to this address to enable them to confirm the win details." %}
+		{% include "wins/partials/win-field.html" with field=form.customer_job_title class="restrict-width-sm" %}
+		{% include "wins/partials/win-field.html" with field=form.customer_location class="restrict-width-sm" %}
+		{% include "wins/partials/form-radio.html" with field=form.business_potential class="restrict-width-sm" help="For ITA and UK region use only." %}
+		{% if win.complete %}
+
+			{% if win.export_experience_display %}
+			<div class="panel panel-info">
+				<p class="panel-heading">The win has been sent to the customer and these details cannot be edited.</p>
+				<div class="panel-body">
+					{% include "wins/partials/win-details-element.html" with name="Export Experience" val=win.export_experience_display %}
+				</div>
+			</div>
+			{% endif %}
+
+		{% else %}
+			{% include "wins/partials/form-radio.html" with field=form.export_experience class="restrict-width-sm" help="Your customer will be asked to confirm this information." %}
+		{% endif %}
+
+		<h3 class="form-section-heading">Win details</h3>
+		<p>
+			Your customer will be asked to confirm this information.
+		</p>
+
+
+	{% if win.complete %}
+
+		<div class="panel panel-info">
+			<p class="panel-heading">The win has been sent to the customer and these details cannot be edited.</p>
+			<div class="panel-body">
+				{% include "wins/partials/win-details-element.html" with name="Country" val=win.country_name %}
+				{% include "wins/partials/win-details-element.html" with name="Date" val=win.date %}
+				{% include "wins/partials/win-details-element.html" with name="How was the company supported in achieving this win?" val=win.description %}
+			</div>
+		</div>
+
+	{% else %}
+
+		{% include "wins/partials/win-field.html" with field=form.country class="restrict-width-sm" %}
+		{% include "wins/partials/win-field.html" with field=form.date help="Enter month and year in the format MM/YYYY." class="restrict-width-xsm" %}
+		{% include "wins/partials/win-field.html" with field=form.description help="Describe the support that had the most impact, or would be the most memorable for the customer, in 50 words or fewer." class="restrict-width" %}
+
+	{% endif %}
+
+		{% include "wins/partials/win-field.html" with field=form.name_of_customer class="restrict-width" help="Write &#39;Confidential&#39; if your customer has specified this." %}
+
+		{% include "wins/partials/win-field.html" with field=form.business_type help="Examples: export sales, contract, order, distributor, tender/competition win, joint venture, outward investment etc." class="restrict-width" %}
+{% comment %}
+		<p>
+			These questions help us to understand the &pound; value of the customer's win
+			over a five year period. How much of that &pound; value is UK exports and how
+			much is business success value. We will use these aggregated values to help
+			demonstrate the contribution to the Government's &pound;1 trillion by 2020
+			export target.
+			<br>
+			<br>
+			Please see guidance and FAQs.
+		</p>
+{% endcomment %}
+
+	{% if win.complete %}
+
+		<div class="panel panel-info">
+			<p class="panel-heading">The win has been sent to the customer and these details cannot be edited.</p>
+			<div class="panel-body">
+
+				<h4>Export value</h4>
+				<p>
+					Total export value over the next 5 years.
+				</p>
+				{% include "wins/partials/win-value-table-complete.html" with fields=win.breakdowns.exports %}
+				<p class="export-year-value">Total: &pound;{{ win.total_expected_export_value | intcomma }}</p>
+
+
+				<h4 class="business-success-heading">Business success value</h4>
+				<p>
+					Total business success value over the next 5 years.
+				</p>
+				{% include "wins/partials/win-value-table-complete.html" with fields=win.breakdowns.nonexports %}
+				<p class="export-year-value">Total: &pound;{{ win.total_expected_non_export_value | intcomma }}</p>
+
+
+				<h4 class="non-export-heading">ODI value</h4>
+				<p>
+					Total Outward Direct Investment value over the next 5 years.
+				</p>
+				{% include "wins/partials/win-value-table-complete.html" with fields=win.breakdowns.odi %}
+				<p class="export-year-value">Total: &pound;{{ win.total_expected_odi_value | intcomma }}</p>
+
+			</div>
+		</div>
+
+	{% else %}
+
+		<div class="form-group checkbox-group {{ form.types_all.errors|yesno:'error,' }}">
+
+			{{ form.types_all.errors }}
+
+			<h4 class="radio-label">
+				<span class="required">*</span>
+					Type of Win:
+			</h4>
+
+			<p class="help-text" style="padding-top: 10px">Tick all that apply.</p>
+
+			{% comment %}
+				Using manual checkboxes just for UX, don't get saved in model
+			{% endcomment %}
+			{% include "wins/partials/form-checkbox.html" with field=form.type_export %}
+			{% include "wins/partials/form-checkbox.html" with field=form.type_non_export %}
+			{% include "wins/partials/form-checkbox.html" with field=form.type_odi %}
+
+		</div>
+
+
+		{# quick hack using non_field_errors here, since this is the only area which has non-field errors #}
+		{% if form.non_field_errors %}
+			<div class="form-group error">
+				{{ form.non_field_errors }}
+		{% endif %}
+
+		<div id="export-content" class="win-values">
+
+			<h4>Export value over next 5 years</h4>
+			<p class="help-text">(round to nearest &pound;)</p>
+			{% include "wins/partials/win-value-table.html" with field_0=form.breakdown_exports_0 field_1=form.breakdown_exports_1 field_2=form.breakdown_exports_2 field_3=form.breakdown_exports_3 field_4=form.breakdown_exports_4 %}
+			{% include "wins/partials/win-field.html" with field=form.total_expected_export_value help="The total expected value should be the sum of the annual values of the win." class="restrict-width-xsm" %}
+		</div>
+
+		<div id="non-export-content" class="win-values">
+
+			<h4>Business success value over next 5 years</h4>
+			<p class="help-text">(round to nearest &pound;)</p>
+			{% include "wins/partials/win-value-table.html" with field_0=form.breakdown_non_exports_0 field_1=form.breakdown_non_exports_1 field_2=form.breakdown_non_exports_2 field_3=form.breakdown_non_exports_3 field_4=form.breakdown_non_exports_4 %}
+			{% include "wins/partials/win-field.html" with field=form.total_expected_non_export_value help="The total expected value should be the sum of the annual values of the win." class="restrict-width-xsm" %}
+		</div>
+
+		<div id="odi-content" class="win-values">
+
+			<h4>Outward Direct Investment value over next 5 years</h4>
+			<p class="help-text">(round to nearest &pound;)</p>
+			{% include "wins/partials/win-value-table.html" with field_0=form.breakdown_odi_0 field_1=form.breakdown_odi_1 field_2=form.breakdown_odi_2 field_3=form.breakdown_odi_3 field_4=form.breakdown_odi_4 %}
+			{% include "wins/partials/win-field.html" with field=form.total_expected_odi_value help="The total expected value should be the sum of the annual values of the win." class="restrict-width-xsm" %}
+		</div>
+
+		{% if form.non_field_errors %}
+			</div>
+		{% endif %}
+
+	{% endif %}
+
+		{% include "wins/partials/form-radio.html" with field=form.goods_vs_services %}
+		{% include "wins/partials/win-field.html" with field=form.name_of_export class="restrict-width" %}
+		{% include "wins/partials/win-field.html" with field=form.sector class="restrict-width-lg" %}
+		<div class="collapsible-container">
+			<button type="button" class="collapsible-button" onclick="toggleCollapsible()">&#9660;</button>
+			<span class="collapsible-text" onclick="toggleCollapsible()">Oil and gas sector important information</span>
+		</div>
+		<div class="collapsible-content" id="collapsibleContent">
+			<div class="content-inner">
+				<p>Since 2021 the UK does not provide financial or promotional support for the fossil fuel energy sector overseas, so only exempt projects can be added.</p>
+				<p>See guidance in <a href="https://www.gov.uk/government/consultations/aligning-uk-international-support-for-the-clean-energy-transition" target="_blank" rel="noopener noreferrer">Aligning UK international support for the clean energy transition.</a></p> 
+				<p>If it doesn't meet the criteria the win will not be approved.</p>
+				<p>To check if your project is exempt contact <a href="mailto:fossilfuelenquiries@trade.gov.uk">fossilfuelenquiries@trade.gov.uk</a></p>
+			</div>
+		</div>
+
+		<h3 class="form-section-heading">Support provided</h3>
+		<p>
+			Did any of these help the customer achieve this win?
+		</p>
+
+		{% include "wins/partials/win-field.html" with field=form.hvc class="restrict-width" %}
+		{% include "wins/partials/form-checkbox-legacy.html" with field=form.has_hvo_specialist_involvement %}
+		{% include "wins/partials/form-checkbox-legacy.html" with field=form.is_prosperity_fund_related %}
+		{% include "wins/partials/form-checkbox-legacy.html" with field=form.is_e_exported %}
+
+		<div class="add-select-group">
+			{% include "wins/partials/win-field.html" with field=form.type_of_support_1 class="restrict-width support-group" %}
+			{% include "wins/partials/win-field.html" with field=form.type_of_support_2 class="restrict-width support-group" %}
+			{% include "wins/partials/win-field.html" with field=form.type_of_support_3 class="restrict-width support-group" %}
+		</div>
+
+		<div class="add-select-group">
+			{% include "wins/partials/win-field.html" with field=form.associated_programme_1 class="restrict-width programme-group" %}
+			{% include "wins/partials/win-field.html" with field=form.associated_programme_2 class="restrict-width programme-group" %}
+			{% include "wins/partials/win-field.html" with field=form.associated_programme_3 class="restrict-width programme-group" %}
+			{% include "wins/partials/win-field.html" with field=form.associated_programme_4 class="restrict-width programme-group" %}
+			{% include "wins/partials/win-field.html" with field=form.associated_programme_5 class="restrict-width programme-group" %}
+		</div>
+
+		{# these manually place the label before the field #}
+
+		<div class="form-group {{ form.is_personally_confirmed.errors|yesno:'error,' }}">
+			{{ form.is_personally_confirmed.errors }}
+			{{ form.is_personally_confirmed }}
+			{% if form.is_personally_confirmed.field.required %}<span class="required">*</span>{% endif %} {{ form.is_personally_confirmed.label_tag }}
+			{% if form.is_personally_confirmed.help_text %}<div class="help-text">{{ form.is_personally_confirmed.help_text }}</div>{% endif %}
+			<div class="clearfix"></div>
+		</div>
+
+		<div class="form-group {{ form.is_line_manager_confirmed.errors|yesno:'error,' }}">
+			{{ form.is_line_manager_confirmed.errors }}
+			{{ form.is_line_manager_confirmed }}
+			{% if form.is_line_manager_confirmed.field.required %}<span class="required">*</span>{% endif %} {{ form.is_line_manager_confirmed.label_tag }}
+			{% if form.is_line_manager_confirmed.help_text %}<div class="help-text">{{ form.is_line_manager_confirmed.help_text }}</div>{% endif %}
+			<div class="clearfix"></div>
+		</div>
+
+		<div class="end-buttons">
+			<input type="submit" name="save" value="Save" class="btn btn-primary">
+			<a href="{% url 'index' %}" class="btn btn-default">Cancel</a>
+		</div>
+
+	</form>
+</div>
+
 {% endblock content %}
+
+
+{% block js_footer %}
+	<script>
+		ew.pages.officerForm({
+			isComplete: ( '{{ win.complete }}' === 'True' ),
+			formId: 'win-form',
+			descriptionId: '{{ form.description.auto_id }}',
+			country: {
+				remove: 'GB',
+				id: '{{ form.country.auto_id }}',
+				value: '{{ form.country.value }}'
+			},
+			supportGroup: {
+				selector: '.support-group select',
+				required: true,
+				buttonText: 'Add a support type',
+				labelText: 'What type of support was given?'
+			},
+			programmeGroup: {
+				required: true,
+				selector: '.programme-group select',
+				buttonText: 'Add an associated programme',
+				labelText: 'Was there an associated programme, event or activity that contributed to the win?',
+				minVisible: 1
+			},
+			exportType: {
+				exportValue: '{{ form.type_export.auto_id }}',
+				nonExportValue: '{{ form.type_non_export.auto_id }}',
+				odiValue: '{{ form.type_odi.auto_id }}'
+			},
+			exportContentId: 'export-content',
+			nonExportContentId: 'non-export-content',
+			odiContentId: 'odi-content',
+			exportValues: [
+				'{{ form.breakdown_exports_0.auto_id }}',
+				'{{ form.breakdown_exports_1.auto_id }}',
+				'{{ form.breakdown_exports_2.auto_id }}',
+				'{{ form.breakdown_exports_3.auto_id }}',
+				'{{ form.breakdown_exports_4.auto_id }}'
+			],
+			exportTotal: '{{ form.total_expected_export_value.auto_id }}',
+			nonExportValues: [
+				'{{ form.breakdown_non_exports_0.auto_id }}',
+				'{{ form.breakdown_non_exports_1.auto_id }}',
+				'{{ form.breakdown_non_exports_2.auto_id }}',
+				'{{ form.breakdown_non_exports_3.auto_id }}',
+				'{{ form.breakdown_non_exports_4.auto_id }}'
+			],
+			nonExportTotal: '{{ form.total_expected_non_export_value.auto_id }}',
+			odiValues: [
+				'{{ form.breakdown_odi_0.auto_id }}',
+				'{{ form.breakdown_odi_1.auto_id }}',
+				'{{ form.breakdown_odi_2.auto_id }}',
+				'{{ form.breakdown_odi_3.auto_id }}',
+				'{{ form.breakdown_odi_4.auto_id }}'
+			],
+			odiTotal: '{{ form.total_expected_odi_value.auto_id }}',
+			winDate: '{{ form.date.auto_id }}'
+		});
+		function toggleCollapsible() {
+			var collContent = document.getElementById("collapsibleContent");
+			var collButton = document.querySelector(".collapsible-button");
+			collButton.classList.toggle("active");
+			if (collContent.style.maxHeight) {
+				collContent.style.maxHeight = null;
+			} else {
+				collContent.style.maxHeight = collContent.scrollHeight + "px";
+			}
+		}
+	</script>
+{% endblock js_footer %}

--- a/wins/templates/wins/win-form.html
+++ b/wins/templates/wins/win-form.html
@@ -5,6 +5,10 @@
 {% block title %} - Create new win for {{ financial_year }} {% endblock %}
 {% block breadcrumb-name %}Create new win for {{ financial_year }} {% endblock %}
 {% block header %}Create new win for {{ financial_year }}{% endblock %}
+{% block content %}
+	{% include "wins/partials/moving-to-datahub.html" %}
+{% endblock content %}
+
 
 {% block banner %}
 	<div class="visible-print-block">


### PR DESCRIPTION
Fixes an issue when instead of the _edit export win_ form, there was only a message about moving to Data Hub.