### PR TITLE
Changed color from orange to blue

### DIFF
--- a/wins/templates/wins/my-wins.html
+++ b/wins/templates/wins/my-wins.html
@@ -10,7 +10,7 @@
   <p style="
         border: 5px solid;
         padding: 30px;
-        color: #F47738;
+        color: #064779;
         font-size: 21px;
         font-style: normal;
         font-weight: 700;
@@ -19,7 +19,7 @@
     Export Wins has moved, all new wins must be added to
     <a href="https://www.datahub.trade.gov.uk/"
       target="_blank"
-      style="color: #F47738; text-decoration: underline;"
+      style="color: #064779; text-decoration: underline;"
     >Data Hub</a>.
   </p>
 {% endblock moved-to-datahub %}


### PR DESCRIPTION
This PR updates the color of the _moving to DataHub_ warning from orange to blue.

## Screenshots

### Before
<img width="1020" alt="Screenshot 2024-04-29 at 14 39 48" src="https://github.com/uktrade/export-wins-ui/assets/2333157/01e8245b-a409-4435-a438-b99ac128863b">

### After
<img width="1024" alt="Screenshot 2024-04-29 at 14 38 47" src="https://github.com/uktrade/export-wins-ui/assets/2333157/e68eb5fb-c797-43e8-884c-6f54e6b9f476">
